### PR TITLE
ui: update product selection and detail display in BotResponse component

### DIFF
--- a/frontend/components/blocks/ProductList.tsx
+++ b/frontend/components/blocks/ProductList.tsx
@@ -1,24 +1,17 @@
 import { Product } from "@/types";
 import React, { memo } from "react";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "../ui/tooltip";
 
 interface ProductListProps {
   products: Product[];
+  onProductSelect: (product: Product) => void;
 }
 
-const ProductList: React.FC<ProductListProps> = memo(function ProductList({ products }) {
+const ProductList: React.FC<ProductListProps> = memo(function ProductList({ products, onProductSelect }) {
   return (
     <ul className="mb-2 list-disc pl-5">
       {products.map((product) => (
-        <li key={product.id} className="mb-1">
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger className="cursor-pointer text-blue-600 hover:underline">{product.name}</TooltipTrigger>
-              <TooltipContent>
-                <ProductDetails product={product} />
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+        <li key={product.id} className="cursor-pointer text-blue-600 hover:underline" onClick={() => onProductSelect(product)}>
+          {product.name}
         </li>
       ))}
     </ul>

--- a/frontend/components/sections/ProductDetail.tsx
+++ b/frontend/components/sections/ProductDetail.tsx
@@ -13,6 +13,7 @@ interface ProductDetailProps {
   state: DisplayProductState;
   product: Product | null;
   actions: ProductActions;
+  displayOnly?: boolean;
 }
 
 const formatLabel = (key: string): string => {
@@ -22,7 +23,7 @@ const formatLabel = (key: string): string => {
     .join(" ");
 };
 
-const ProductDetail = ({ state, product, actions }: ProductDetailProps) => {
+const ProductDetail = ({ state, product, actions, displayOnly = false }: ProductDetailProps) => {
   console.log(`ProductDetail state: ${state}`);
   const [editedProduct, setEditedProduct] = useState<Product | null>(product);
 
@@ -87,10 +88,14 @@ const ProductDetail = ({ state, product, actions }: ProductDetailProps) => {
         content = renderProductFields(false);
         footer = (
           <>
-            <Button onClick={actions.click.selectUpdateProduct}>Update Product</Button>
-            <Button variant="destructive" onClick={actions.click.selectDeleteProduct}>
-              Delete Product
-            </Button>
+            {!displayOnly && (
+              <>
+                <Button onClick={actions.click.selectUpdateProduct}>Update Product</Button>
+                <Button variant="destructive" onClick={actions.click.selectDeleteProduct}>
+                  Delete Product
+                </Button>
+              </>
+            )}
           </>
         );
         break;


### PR DESCRIPTION
* Updated the bot results to display product details in a separate modal when the user clicks on a product item. This replaces the previous hover-based popover, improving usability and accessibility.

<img width="1431" alt="Screenshot 2024-12-06 at 12 46 57 in the afternoon" src="https://github.com/user-attachments/assets/6e11cb5d-98a3-4cec-ae01-1cba926983e7">
